### PR TITLE
fetch partially matched contracts on remix

### DIFF
--- a/src/components/contract-fetcher/ContractFetcher.tsx
+++ b/src/components/contract-fetcher/ContractFetcher.tsx
@@ -108,6 +108,12 @@ export const ContractFetcher: React.FC = () => {
                                    </Alert>
                 }
                 {
+                    (!state.error && stateContext?.fetchResult?.verificationStatus === 'partial') && (
+                        <Alert type={'warning'} heading='This is a partially matched contract!'>
+                        </Alert>
+                    )
+                }
+                {
                     !state.error && stateContext.fetchResult && (
                         <Alert type={'success'} heading='Contract successfully fetched!'>
                         </Alert>

--- a/src/remix/RemixClient.ts
+++ b/src/remix/RemixClient.ts
@@ -110,7 +110,7 @@ export class RemixClient extends PluginClient {
     }
 
     fetchFiles = async (chain: any, address: string) => {
-        const response = await axios.get(`${SERVER_URL}/files/${chain}/${address}`)
+        const response = await axios.get(`${SERVER_URL}/files/any/${chain}/${address}`)
         return response;
     }
 
@@ -139,11 +139,13 @@ export class RemixClient extends PluginClient {
                 }
 
                 const fetchResult: FetchResult = {
+                    verificationStatus: '',
                     metadata: null,
                     sources: []
                 };
 
-                for (const file of response.data) {
+                fetchResult.verificationStatus = response.data.status
+                for (const file of response.data.files) {
                     if (file.name === "metadata.json") {
                         if (fetchResult.metadata) {
                             return reject({ info: "Multiple metadata files fetched" });

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -5,6 +5,7 @@ export type Source = {
 }
 
 export type FetchResult = {
+    verificationStatus: string,
     metadata: any,
     sources: Source[]
 }


### PR DESCRIPTION
When fetching contracts from the repository, the Fetcher module is not able to retrieve partially matched contracts, and throws 
```
This contract could not be loaded. Please check the address. Error: Request failed with status code 404. Network: 1
```

It should be able to fetch partially matched contracts. The module would warn the user (via an alert, notification etc.) that this is a partially matched contract when fetched.

Closes https://github.com/ethereum/sourcify/issues/614