### PR TITLE
Update network dropdown label from name to title property

### DIFF
--- a/src/components/contract-fetcher/ContractFetcher.tsx
+++ b/src/components/contract-fetcher/ContractFetcher.tsx
@@ -69,7 +69,7 @@ const ContractFetcher = React.memo(({ chains }: Props) => {
 
     const parsedChains = useMemo(() => chains.map((chain) => {
         return {
-            label: chain.name,
+            label: chain.title || chain.name,
             value: chain.chainId,
             id: chain.chainId
         }

--- a/src/components/verify-contract/VerifyContract.tsx
+++ b/src/components/verify-contract/VerifyContract.tsx
@@ -91,7 +91,7 @@ const VerifyContract = React.memo(({ chains }: Props) => {
 
     const parsedChains = useMemo(() => chains.map((chain) => {
         return {
-            label: chain.name,
+            label: chain.title || chain.name,
             value: chain.chainId,
             id: chain.chainId
         }


### PR DESCRIPTION
Before this change, the remix network dropdown label displays the name field rather than title. This makes it difficult to discover testnets if searching by the mainnet.  
- Expected behavior: Polygon Mumbai is listed underneath Polygon Mainnet.
- Problem: "Mumbai" isn't listed underneath Polygon Mainnet because it is named "Mumbai" but titled "Polygon Testnet Mumbai.

![image](https://user-images.githubusercontent.com/91382964/187959457-97d683f0-fad8-45ef-9dd2-a85d5300b97a.png)

https://chainid.network/chains.json

{
    "name": "Mumbai",
    "title": "Polygon Testnet Mumbai",
    ....
}